### PR TITLE
Updated engineering to add point on sharing/writing content

### DIFF
--- a/Engineering.md
+++ b/Engineering.md
@@ -22,6 +22,7 @@
 - I reach out to my peers and leadership group to develop my personal growth plan.
 - I am a self-managing team member, I make and keep my commitments using the privilege of flexibility wisely.
 - I am applying agile practices in my day to day work, and I am beginning to understand why they are important to software development
+- I share my lessons learned and interesting technical decision points by writing content for the Octopus Blog.
 
 ### I am an egoless, team oriented developer
 


### PR DESCRIPTION
Writing blog posts is a part of the Octopus DNA. Paul wrote the following in 2014, and it still holds.

> We blog. And not in a sleazy, content marketing, click-bait way. We blog about what we're working on, and lessons we've learned along the way. We blog plans for the future, feature concepts, and problems we're having.  

This one line PR attempts to capture this and kickoff more writing from our broader team.