### PR TITLE
Engineering manager roles

### DIFF
--- a/Engineering-Management.md
+++ b/Engineering-Management.md
@@ -1,0 +1,63 @@
+# Software Engineering Manager Roles
+
+## L4 Engineering Manager
+
+> I guide a team of ICs to deliver business impact with support from my manager
+
+### :triangular_flag_on_post: Leadership
+- I take accountability for the engineers in my team, the way they work, and the results they deliver.
+- I follow through on my commitments and take accountability for my work and the work of my team 
+- When it comes to team planning, I’m responsible for bringing my unique knowledge of the people on our team, headcount constraints, and other people-related matters
+- I empower my team to get things done and I drive results collaboratively.
+- I clarify the goals, roles, and execution plans for my team.
+- I help my team understand our strategy and how they are contributing to the big picture.
+- I collaborate with engineering leaders in other teams with positive results
+- I write and speak with clarity, tailor my message to my audience, and listen to understand others
+- I proactively share information so the right people are informed and aligned
+
+### :deciduous_tree: Talent
+- I take accountability for the engineering talent on my team and their career growth.
+- I can effectively resolve issues with underperformers with some guidance from my manager
+- I can confidently and proactively coach engineers up to senior (L3) level, accelerating them along their personal growth trajectory. I can coach engineers beyond senior (L3) level with support from my manager
+- I give direct feedback which is timely, actionable, and helpful. The feedback I give in performance reviews is rarely a surprise because it summarises the timely, actionable, and helpful feedback my teammate has been receiving.
+- I am learning how to think about the talent on my team strategically: how to create growth opportunities for team members while addressing gaps and risks through recruiting, training, and performance management
+- I structure my team so the right people are in the right roles with clearly defined responsibilities. In consultation with my manager, I ensure projects are staffed appropriately to set them up for success, placing my strongest technical leaders where they are the most needed and impactful
+
+### :octopus: Culture
+- I take accountability for the culture of my team
+- I keep my team focused on quality and regular releases
+- I keep my team focused on customer success
+- I help my team navigate organisational change
+- I am sensitive to the needs of my team, and I proactively help my team through difficult situations
+- I recognise dysfunction in my team and work effectively to resolve it in a timely manner.
+- I listen to different perspectives and I remove biases from my words and actions 
+- I create an inclusive environment for my team where it’s safe to speak up
+
+## L5 Senior Engineering Manager
+
+> I employ a robust managerial toolbox to independently lead a team, or teams of engineers delivering direct business impact
+
+### :triangular_flag_on_post: Leadership
+- I am able to independently identify and tackle projects that solve open-ended, ambiguous problems that are often beyond the scope of my immediate team.
+- I take accountability for the people in my team or teams, the way they work, and the results they deliver.
+- I am effective at influencing outcomes across multiple teams and with cross-functional partners, often requiring conflict resolution and managing ambiguity.
+- I identify ways that my team can work more effectively with other teams in the company and create lasting change
+- I drive impactful outcomes in the face of significant organizational and technical ambiguity and change.
+- I write and speak with clarity, tailor my message to my audience, and listen to understand others
+- I proactively share information so the right people are informed and aligned
+
+### :deciduous_tree: Talent
+- I autonomously guide my team to the sustainable delivery of business impact through my mastery of execution and people management.
+- I am sensitive to the needs of my team or teams, and I proactively help them through difficult situations
+- I can confidently and effectively resolve issues with underperformers
+- I proactively coach engineers up to Principal (L5) level, accelerating them along their personal growth trajectory.
+- I give radically candid feedback which is timely, actionable, and helpful. The feedback I give in performance reviews is rarely a surprise because it summarises the timely, actionable, and helpful feedback my teammate has been receiving.
+- I have a strong pulse on my team's engagement and a proactive retention strategy
+
+### :octopus: Culture
+- I take responsibility for the culture of my team, and I am a positive contributor to Octopus's culture as a whole
+- I am a champion for diversity, equity and inclusion at Octopus
+- I recognise dysfunction in my team and across the broader organization, working effectively with other leaders as necessary to resolve it in a timely manner.
+- I create a team culture that is resilient and adaptable to organisational change
+- I cultivate a healthy environment of growth and support that empowers my teams to consistently deliver at a high level of impact.
+- I remove barriers to inclusion for my team and ensure diverse perspectives are considered and included

--- a/Engineering-Management.md
+++ b/Engineering-Management.md
@@ -48,13 +48,13 @@
 
 ### :deciduous_tree: Talent
 - I autonomously guide my team to the sustainable delivery of business impact through my mastery of execution and people management.
-- I am sensitive to the needs of my team or teams, and I proactively help them through difficult situations
 - I can confidently and effectively resolve issues with underperformers
 - I proactively coach engineers up to Principal (L5) level, accelerating them along their personal growth trajectory.
 - I give radically candid feedback which is timely, actionable, and helpful. The feedback I give in performance reviews is rarely a surprise because it summarises the timely, actionable, and helpful feedback my teammate has been receiving.
 - I have a strong pulse on my team's engagement and a proactive retention strategy
 
 ### :octopus: Culture
+- I am sensitive to the needs of my team or teams, and I proactively help them through difficult situations
 - I take responsibility for the culture of my team, and I am a positive contributor to Octopus's culture as a whole
 - I am a champion for diversity, equity and inclusion at Octopus
 - I recognise dysfunction in my team and across the broader organization, working effectively with other leaders as necessary to resolve it in a timely manner.

--- a/Engineering-Management.md
+++ b/Engineering-Management.md
@@ -54,10 +54,10 @@
 - I have a strong pulse on my team's engagement and a proactive retention strategy
 
 ### :octopus: Culture
-- I am sensitive to the needs of my team or teams, and I proactively help them through difficult situations
-- I take responsibility for the culture of my team, and I am a positive contributor to Octopus's culture as a whole
+- I take accountability for the culture of my team, and I am a positive contributor to Octopus's culture as a whole
 - I am a champion for diversity, equity and inclusion at Octopus
 - I recognise dysfunction in my team and across the broader organization, working effectively with other leaders as necessary to resolve it in a timely manner.
+- I am sensitive to the needs of my team or teams, and I proactively help them through difficult situations
 - I create a team culture that is resilient and adaptable to organisational change
 - I cultivate a healthy environment of growth and support that empowers my teams to consistently deliver at a high level of impact.
 - I remove barriers to inclusion for my team and ensure diverse perspectives are considered and included

--- a/Software-Engineering.md
+++ b/Software-Engineering.md
@@ -145,9 +145,9 @@ _We avoid distinguishing too much between the Junior Software Engineer and Softw
 - I actively blog about the lessons we are learning as we improve engineering excellence to clarify our thinking, reinforce the learning, attract customers and potential future employees
 - I have a proven track record of expertly tailoring my communication to the target audience with a result of increased clarity and impact
 
-## Engineering Manager
+## Tech Lead / Engineering Manager
 
-_We consider an engineering manager to be a full time role building on top of the Lead Software Engineer. See the [manager's handbook](https://octopushq.atlassian.net/wiki/spaces/IN/pages/628981849/Managers+at+Octopus)._
+_We consider a tech lead / engineering manager to be a full time role building on top of the Lead Software Engineer. See the [manager's handbook](https://octopushq.atlassian.net/wiki/spaces/IN/pages/628981849/Managers+at+Octopus)._
 
 > I take responsibility for 6-10 people in the engineering team and the results they ultimately deliver.
 > An Engineering Manager encompasses all of the qualities listed in [Leadership](Leadership.md) and is usually a full-time role.


### PR DESCRIPTION
Up until recently, all Engineering Manager roles at Octopus Deploy were defined as an extension of the Lead Engineer role. Now there is an additional people-focused role deserving of its own ladder. This update introduces this role as Engineering Manager and Senior Engineering Manager. The old definition for engineering manager still applies to some, so this has been redefined as "Tech Lead / Engineering Manager" to differentiate from this new role.