### PR TITLE
Remove duplicated lines from Lead Software Engineer

### DIFF
--- a/Software-Engineering.md
+++ b/Software-Engineering.md
@@ -114,7 +114,6 @@ _We avoid distinguishing too much between the Junior Software Engineer and Softw
 - I structure my work according to these priorities: coordinate, communicate, then contribute.
 - I understand our organisation structure and how we schedule work (ShapeUp, QRF, etc) and I help my team be net-positive contributors in this environment.
 - I understand our fixed-time/high-quality/variable-scope approach to software projects and I make good tradeoffs using tools like the "scope hammer" and "safety nets".
-- I am comfortable with transparently assessing risk, making recommendations, escalating appropriately, and dealing with the consequences along the way.
 - I can confidently and charismatically pitch ideas, positively influencing my team to take decisive action based on reaching consensus.
 - I am an adept communicator, and can effectively steer technical and non-technical conversations to positive outcomes over any medium.
 

--- a/Software-Engineering.md
+++ b/Software-Engineering.md
@@ -93,7 +93,6 @@ _We avoid distinguishing too much between the Junior Software Engineer and Softw
 - I am comfortable with transparently assessing risk, making recommendations, escalating appropriately, and dealing with the consequences along the way.
 - I am comfortable building a product vision based on the needs of multiple customers, regardless of whether this involves technology or otherwise.
 - I can confidently and charismatically pitch ideas, positively influencing and convincing people to take decisive action based on reaching consensus.
-- I am an adept communicator, and can effectively steer technical and non-technical conversations to positive outcomes over any medium.
 
 ### I help our team focus on delivering value to our customers
 


### PR DESCRIPTION
The statement

> I am an adept communicator, and can effectively steer technical and non-technical conversations to positive outcomes over any medium.

featured under multiple categories for Lead Software Engineer, adding unnecessary bloat to the page. It remains on line 118 of the new version under the heading: **I am trusted to lead a team of diverse technical roles**

Remove statement

> I am comfortable with transparently assessing risk, making recommendations, escalating appropriately, and dealing with the consequences along the way.

from the section **I am trusted to lead a team of diverse technical roles** as it is duplicated in the section **I am trusted to ship a brand new idea to production with limited supervision** (line 93)