### PR TITLE
L4 sre

### DIFF
--- a/Site-Reliability-Engineering/L4-Lead-Site-Reliability-Engineer.md
+++ b/Site-Reliability-Engineering/L4-Lead-Site-Reliability-Engineer.md
@@ -1,0 +1,59 @@
+# L4: Lead Site Reliability Engineer
+
+> _I am a well-rounded engineer, architect and problem solver. I can be trusted to take a brand new idea from inception to production, bringing people along with me throughout the process and providing clarity for our team. I am trusted to autonomously lead people through complex cross-team reliability problems with a proven record of delivering ideas from inception to their successful completion._ 
+
+- **Planning horizon**: 6-12 months
+- **Impact radius**: Team (5-15)
+- **Evaluation**: Manager or Director
+- **Responsibility and direction needed**: Takes brand new ideas from inception to production with limited supervision.
+
+## 🦉 Domain expertise
+- I am a well-rounded engineer, architect and problem solver
+- I am an expert in my team's domain
+- I am comfortable diving head-first into moderately risky situations with relatively little upfront information and oversight
+- I am confident in making architectural decisions, taking cross-cutting concerns (for example, infrastructure, identity management, security, scalability, concurrency, and maintainability) into consideration as appropriate.
+- I stay up to date on evolving platform engineering standards, platform features, and critical vendor and community-provided technologies.
+
+<details>
+<summary>Examples</summary>
+
+I successfully completed a large, complex project with multiple components and stakeholders beyond my immediate team.
+I dived head-first into an incident (in my area of ownership) in an area of significant technical ambiguity or risk, led the investigation and resolved the issue by removing noise around the incident to allow the incident response team to solve the issue.
+I strive for automation by coding it or by leading and influencing engineers and developers to build systems that are easy to run in production.
+🌱 Teaching and Mentoring
+I define, document, and evolve best practices for engineering in my team's area of ownership.
+I shepherd and aid in development of new projects across the organization.
+I am constantly working to broaden the technical capabilities of my team.
+I am comfortable with challenging and coaching my peers.
+I help people determine the most valuable ways they can contribute, and grow, and I help them block out the noise.
+▼ Examples
+I provided training and mentoring for multiple team members, deliberately helping them to round out their skill sets.
+I shared my on-the-job learning and experiences with others so they can understand and be more effective in their own roles.
+I broke up a project in such a way that lined up appropriate challenges for each of my teammates that helped them grow.
+I had some difficult conversations with my teammates, challenging them directly while showing them my care for them personally.
+🧭 Culture and Leadership
+I encompass all of the qualities listed in Leadership
+I make sure difficult work that needs to be done gets done, like hard debugging, incident response, and reverse-engineering tasks
+I understand our organisation structure and how we schedule work, and help my team find their highest value contributions in this environment.
+I am comfortable with transparently assessing risk, making recommendations, escalating appropriately, and dealing with the consequences along the way.
+I recognise problems and proactively engage with other people to prevent or resolve them quickly.
+I am comfortable coordinating projects where success requires the input of multiple teams and diverse technical roles.
+I am an adept communicator, and can effectively steer technical and non-technical conversations to positive outcomes over any medium.
+▼ Examples
+I identified the work involved with delivering a “Pitch”, broke it into tasks and managed the project to completion.
+I took ownership of my team's retrospective process, making sure everyone had a voice in how our team works and evolves together.
+I performed interviews for engineering candidates, providing detailed and useful feedback 
+I confidently pitched an idea, positively influencing and convincing people to take decisive action.
+I effectively steered technical and non-technical conversations to positive outcomes.
+I was typically the first to take responsibility for reducing waste in our process.
+I noticed a project was going to become blocked by another team, or take longer than expected, so I pulled together relevant stakeholders to propose an updated plan and reach a consensus.
+🏆 Customer Success
+I invest in sustainable delivery, maintaining professional standards and striking a pragmatic balance between idealistic purity and business pressures.
+I understand our fixed-time/high-quality/variable-scope approach to software projects.
+I assess what work supports the product strategy and make insightful recommendations regarding priorities.
+I identify key gaps in product offerings and functionality that will drive significant revenue and customer excitement.
+I pragmatically plan minimum viable infrastructure for product launch.
+▼ Examples
+I contributed to shaping a pitch, identified risks and appropriate scoping, that helped us ship value to customers as soon as possible, and meet the team's objectives over one or more cycles.
+I was comfortable building a product vision based on the needs of multiple customers.
+In delivering a pitch, I used the "scope hammer" judiciously, to maintain high quality while shipping as much value as possible to users within a cycle.

--- a/Site-Reliability-Engineering/L4-Lead-Site-Reliability-Engineer.md
+++ b/Site-Reliability-Engineering/L4-Lead-Site-Reliability-Engineer.md
@@ -8,52 +8,75 @@
 - **Responsibility and direction needed**: Takes brand new ideas from inception to production with limited supervision.
 
 ## 🦉 Domain expertise
+
 - I am a well-rounded engineer, architect and problem solver
 - I am an expert in my team's domain
 - I am comfortable diving head-first into moderately risky situations with relatively little upfront information and oversight
-- I am confident in making architectural decisions, taking cross-cutting concerns (for example, infrastructure, identity management, security, scalability, concurrency, and maintainability) into consideration as appropriate.
-- I stay up to date on evolving platform engineering standards, platform features, and critical vendor and community-provided technologies.
+- I am confident in making architectural decisions, taking cross-cutting concerns (for example, infrastructure, identity management, security, scalability, concurrency, reliability and maintainability) into consideration as appropriate.
+- I stay up to date on evolving platform and reliability engineering standards, platform features, and critical vendor and community-provided technologies.
+
 
 <details>
 <summary>Examples</summary>
 
-I successfully completed a large, complex project with multiple components and stakeholders beyond my immediate team.
-I dived head-first into an incident (in my area of ownership) in an area of significant technical ambiguity or risk, led the investigation and resolved the issue by removing noise around the incident to allow the incident response team to solve the issue.
-I strive for automation by coding it or by leading and influencing engineers and developers to build systems that are easy to run in production.
-🌱 Teaching and Mentoring
-I define, document, and evolve best practices for engineering in my team's area of ownership.
-I shepherd and aid in development of new projects across the organization.
-I am constantly working to broaden the technical capabilities of my team.
-I am comfortable with challenging and coaching my peers.
-I help people determine the most valuable ways they can contribute, and grow, and I help them block out the noise.
-▼ Examples
-I provided training and mentoring for multiple team members, deliberately helping them to round out their skill sets.
-I shared my on-the-job learning and experiences with others so they can understand and be more effective in their own roles.
-I broke up a project in such a way that lined up appropriate challenges for each of my teammates that helped them grow.
-I had some difficult conversations with my teammates, challenging them directly while showing them my care for them personally.
-🧭 Culture and Leadership
-I encompass all of the qualities listed in Leadership
-I make sure difficult work that needs to be done gets done, like hard debugging, incident response, and reverse-engineering tasks
-I understand our organisation structure and how we schedule work, and help my team find their highest value contributions in this environment.
-I am comfortable with transparently assessing risk, making recommendations, escalating appropriately, and dealing with the consequences along the way.
-I recognise problems and proactively engage with other people to prevent or resolve them quickly.
-I am comfortable coordinating projects where success requires the input of multiple teams and diverse technical roles.
-I am an adept communicator, and can effectively steer technical and non-technical conversations to positive outcomes over any medium.
-▼ Examples
-I identified the work involved with delivering a “Pitch”, broke it into tasks and managed the project to completion.
-I took ownership of my team's retrospective process, making sure everyone had a voice in how our team works and evolves together.
-I performed interviews for engineering candidates, providing detailed and useful feedback 
-I confidently pitched an idea, positively influencing and convincing people to take decisive action.
-I effectively steered technical and non-technical conversations to positive outcomes.
-I was typically the first to take responsibility for reducing waste in our process.
-I noticed a project was going to become blocked by another team, or take longer than expected, so I pulled together relevant stakeholders to propose an updated plan and reach a consensus.
-🏆 Customer Success
-I invest in sustainable delivery, maintaining professional standards and striking a pragmatic balance between idealistic purity and business pressures.
-I understand our fixed-time/high-quality/variable-scope approach to software projects.
-I assess what work supports the product strategy and make insightful recommendations regarding priorities.
-I identify key gaps in product offerings and functionality that will drive significant revenue and customer excitement.
-I pragmatically plan minimum viable infrastructure for product launch.
-▼ Examples
-I contributed to shaping a pitch, identified risks and appropriate scoping, that helped us ship value to customers as soon as possible, and meet the team's objectives over one or more cycles.
-I was comfortable building a product vision based on the needs of multiple customers.
-In delivering a pitch, I used the "scope hammer" judiciously, to maintain high quality while shipping as much value as possible to users within a cycle.
+- I successfully completed a large, complex project with multiple components and stakeholders beyond my immediate team.
+- I dived head-first into an incident (in my area of ownership) in an area of significant technical ambiguity or risk, led the investigation and resolved the issue by removing noise around the incident to allow - the incident response team to solve the issue.
+- I strive for automation by coding it or by leading and influencing engineers and developers to build systems that are easy to run in production.
+
+</details>
+
+## 🌱 Teaching and Mentoring
+- I define, document, and evolve best practices for reliability engineering in my team's area of ownership.
+- I shepherd and aid in development of new projects across the organization.
+- I am constantly working to broaden the technical capabilities of my team.
+- I am comfortable with challenging and coaching my peers.
+- I help people determine the most valuable ways they can contribute, and grow, and I help them block out the noise.
+
+<details>
+<summary> Examples </summary>
+
+- I provided training and mentoring for multiple team members, deliberately helping them to round out their skill sets.
+- I shared my on-the-job learning and experiences with others so they can understand and be more effective in their own roles.
+- I broke up a project in such a way that lined up appropriate challenges for each of my teammates that helped them grow.
+- I had some difficult conversations with my teammates, challenging them directly while showing them my care for them personally.
+
+</details>
+
+## 🧭 Culture and Leadership
+- I encompass all of the qualities listed in Leadership
+- I make sure difficult work that needs to be done gets done, like hard debugging, incident response, and reverse-engineering tasks
+- I understand our organisation structure and how we schedule work, and help my team find their highest value contributions in this environment.
+- I am comfortable with transparently assessing risk, making recommendations, escalating appropriately, and dealing with the consequences along the way.
+- I recognise problems and proactively engage with other people to prevent or resolve them quickly.
+- I am comfortable coordinating projects where success requires the input of multiple teams and diverse technical roles.
+- I am an adept communicator, and can effectively steer technical and non-technical conversations to positive outcomes over any medium.
+
+<details>
+<summary>Examples</summary>
+
+- I identified the work involved with delivering a “Pitch”, broke it into tasks and managed the project to completion.
+- I took ownership of my team's retrospective process, making sure everyone had a voice in how our team works and evolves together.
+- I performed interviews for engineering candidates, providing detailed and useful feedback 
+- I confidently pitched an idea, positively influencing and convincing people to take decisive action.
+- I effectively steered technical and non-technical conversations to positive outcomes.
+- I was typically the first to take responsibility for reducing waste in our process.
+- I noticed a project was going to become blocked by another team, or take longer than expected, so I pulled together relevant stakeholders to propose an updated plan and reach a consensus.
+
+</details>
+
+## 🏆 Customer Success
+
+- I invest in sustainable delivery, maintaining professional standards and striking a pragmatic balance between idealistic purity and business pressures.
+- I understand our fixed-time/high-quality/variable-scope approach to software projects.
+- I assess what work supports the product strategy and make insightful recommendations regarding priorities.
+- I identify key gaps in product offerings and functionality that will drive significant revenue and customer excitement.
+- I pragmatically plan minimum viable infrastructure for product launch.
+
+<details>
+<summary> Examples </summary>
+
+- I contributed to shaping a pitch, identified risks and appropriate scoping, that helped us ship value to customers as soon as possible, and meet the team's objectives over one or more cycles.
+- I was comfortable building a product vision based on the needs of multiple customers.
+- In delivering a pitch, I used the "scope hammer" judiciously, to maintain high quality while shipping as much value as possible to users within a cycle.
+
+</details>

--- a/Site-Reliability-Engineering/README.md
+++ b/Site-Reliability-Engineering/README.md
@@ -17,6 +17,7 @@ The following pages provide demonstrable values and concrete examples to describ
 
 1. [L2: Site Reliability Engineer](L2-Site-Reliability-Engineer.md)
 2. [L3: Senior Site Reliability Engineer](L3-Senior-Site-Reliability-Engineer.md)
+3. [L4: Lead Site Reliability Engineer](L4-Lead-Site-Reliability-Engineer.md)
 
 💡 Tip: To help guide conversations about your progression with your manager, open multiple tabs and contrast the expectations across adjacent levels.
 
@@ -24,23 +25,17 @@ See also: guidance on [Deriving an overall rating (Maturing, Performing, Exceedi
 
 
 # What are SREs?
-SREs understand software systems are not just a pile of code. They understand its purpose, the 
-machinery used to run it, how it\'s managed and that reliable operations require humans to 
-collaborate rather than individual heroism.
+SREs understand software systems are not just a pile of code. They understand its purpose, the machinery used to run it, how it's managed and that reliable operations require humans to collaborate rather than individual heroism.
 
-They help teams to make the right reliability trade offs. They understand how to measure how well
- a system is running, identify the high leverage points and move them to improve the outcomes, 
- costs and/or manage risks. 
+They help teams to make the right reliability trade offs. They understand how to measure how well a system is running, identify the high leverage points and move them to improve the outcomes, costs and/or manage risks. 
 
-They are experts in learning and sharing, from both what works and doesn\'t, are unfazed 
-by chaos, and they will calmly and practically get problems fixed.
+They are experts in learning and sharing, from both what works and doesn't, are unfazed by chaos, and they will calmly and practically get problems fixed.
 
-They likely find lessons from aviation safety culture to be interesting and relevant to their 
-daily work. They\'re equally comfortable leading a postmortem as they are designing a deployment 
-and monitoring pipeline.
+They often thrive in busy operational environments, which further amplifies their desire to automate and build reliable systems which turn into reliable platforms. 
+
+They likely find lessons from aviation safety culture to be interesting and relevant to their daily work. They're equally comfortable leading a postmortem as they are designing a deployment and monitoring pipeline.
 
 ## Picking between Software Engineering and SRE
 For engineers deciding between the two ladders - SREs are engineers who care more about 
-making other engineer\'s code work well than writing the code themselves. Unlike system 
-engineers they err towards automating problems away and are comfortable jumping into 
-the code we run including the tools we use. 
+making other engineer's code work well than writing the code themselves. More so than Software Engineers, SREs err towards automating problems away and are comfortable jumping into 
+the code we run including the tools we use. SREs often have Software Engineering backgrounds, and use that background to apply Software Engineering thinking to operational reliability problems. 


### PR DESCRIPTION
Adding in L4 SRE. 
Updated Readme, bringing in feedback to cover operations in SRE space, and replace system engineer with Software Engineer naming to make it clearer. System Engineer role had been removed from the ladder