### PR TITLE
Document the "Managing Principal Software Engineer" role

### DIFF
--- a/Engineering-Management.md
+++ b/Engineering-Management.md
@@ -36,6 +36,8 @@
 ## L5 Senior Engineering Manager
 
 > I employ a robust managerial toolbox to independently lead a team, or teams of engineers delivering direct business impact
+>
+> _See also: [L5: Managing Principal Software Engineer](Software-Engineering/L5-Managing-Principal-Software-Engineer.md)_
 
 ### :triangular_flag_on_post: Leadership
 - I am able to independently identify and tackle projects that solve open-ended, ambiguous problems that are often beyond the scope of my immediate team.

--- a/Software-Engineering/L5-Managing-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Managing-Principal-Software-Engineer.md
@@ -1,0 +1,31 @@
+# L5: Managing Principal Software Engineer
+
+> _We do not expect more openings for this role; you should choose one of the [Software Engineering](README.md) or [Engineering Management](../Engineering-Management.md) ladders instead._
+
+## Expectations
+
+This role combines some technical and management responsibilities, as follows:
+
+* Includes the expectations of a [Senior Engineering Manager](../Engineering-Management.md#l5-senior-engineering-manager) (EM), but applied to a team of ~1-5 direct reports rather than up to ~10
+* Includes the expectations of a [Principal Software Engineer](L5-Principal-Software-Engineer.md) (PE), but for a narrower domain 
+
+The qualifications above intend to describe realistic constraints within which someone could be both a great EM and great PE for the people in their team. For more details, refer to the individual ladders linked above, keeping these constraints in mind. 
+
+## History
+
+In 2020, this role combining a hybrid of technical and management responsibilities was introduced under the name “Engineering Manager”. This role has been renamed to Managing Principal Software Engineer, to disambiguate it from the distinct [technical](README.md) and [management](../Engineering-Management.md) ladders that were introduced in 2021.
+
+## Usage 
+
+There are only limited scenarios where this role is the best option, because of the broad range of responsibilities being asked of one individual. Risks include:
+
+1. Difficult to hire into
+2. May limit depth of specialization in either individual contribution or management track
+3. More difficult to set expectations
+4. Limits team size
+
+One scenario where this role may be suitable is when a PE with management experience spearheads a new initiative, with that individual taking on both the management and technical leadership of an initially small team and narrow domain. EM responsibilities may then transition to an incoming peer as the team or domain grows.
+
+## Career progression
+
+This is an L5 role and is paid according to the same salary calculator as Software Engineers and Engineering Managers. We are not planning on creating a full career track for this hybrid role. Career progression from this role is possible by moving sideways or upwards via the separate [Software Engineering](README.md) or [Engineering Management](../Engineering-Management.md) ladders.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -1,6 +1,8 @@
 # L5: Principal Software Engineer
 
 > _I am an influential Engineering leader who identifies problems and opportunities relevant to Octopus' strategy, builds consensus to invest in solutions, and guides Engineering to deliver significant lasting change across Octopus._
+>
+> _See also: [L5: Managing Principal Software Engineer](L5-Managing-Principal-Software-Engineer.md)_
 
 - **Planning horizon**: 1+ year
 - **Impact radius**: Group+ (15-50). Note: This role is evolving as the company grows. PSE is right at the top of our IC track. For example, the impact radius expectations of an L5 will likely grow as Octopus grows larger over the next couple years, from 2-4 teams in 2021. We expect the role to stabilise in 2022 once the company has grown to the point of needing an L6 IC engineering role.


### PR DESCRIPTION
In 2020, an L5 role combining a hybrid of technical and management responsibilities was introduced under the name “Engineering Manager”. 

This PR documents the role under the name "Managing Principal Software Engineer", to disambiguate it from the distinct technical and management ladders that were introduced in 2021.

For more information and context, see the role description.