### PR TITLE
Software Engineering ladder refinements (based on feedback from EMs)

### DIFF
--- a/Software-Engineering/L2-Software-Engineer.md
+++ b/Software-Engineering/L2-Software-Engineer.md
@@ -1,6 +1,6 @@
 # L2: Software Engineer
 
-> _I am a valuable and enthusiastic member of an Octopus team. I can work independently on small projects, and am focused on learning with a trajectory of growth into the contribution of a Senior Software Engineer or beyond._
+> _I am a valuable and enthusiastic member of an Octopus team. I can work independently on small projects, and am focused on learning with a trajectory of growth into the contribution of a Senior Software Engineer or beyond. I still require some support from L3s to solve more difficult technical problems that are beyond my current experience level._
 
 - **Planning horizon**: Current and next cycle
 - **Impact radius**: Self plus some team mates

--- a/Software-Engineering/L2-Software-Engineer.md
+++ b/Software-Engineering/L2-Software-Engineer.md
@@ -1,6 +1,6 @@
 # L2: Software Engineer
 
-> _I am a valuable and enthusiastic member of an Octopus team. I can work independently on small projects, and am focused on learning with a trajectory of growth into the contribution of a Senior Software Engineer or beyond. I still require some support from L3s to solve more difficult technical problems that are beyond my current experience level._
+> _I am a valuable and enthusiastic member of an Octopus team. I can work independently on small projects, and am focused on learning with a trajectory of growth into the contribution of a Senior Software Engineer or beyond. I still require some support from Senior Software Engineers to solve more difficult technical problems that are beyond my current experience level._
 
 - **Planning horizon**: Current and next cycle
 - **Impact radius**: Self plus some team mates

--- a/Software-Engineering/L2-Software-Engineer.md
+++ b/Software-Engineering/L2-Software-Engineer.md
@@ -17,6 +17,7 @@
 <summary>Examples</summary>
 
 - I completed maintenance work in a complex area of the codebase, relying on my knowledge of .NET and occasionally reaching out for help from my more senior teammates when I knew I would need it.
+- When faced with a small project, I understood the brief the first time, and was able to reach out myself to find the answers I needed to complete it.
 
 </details>
 

--- a/Software-Engineering/L2-Software-Engineer.md
+++ b/Software-Engineering/L2-Software-Engineer.md
@@ -45,6 +45,7 @@
 - I noticed a section of code that could result in a caching issue, and I modified it to prevent the issue.
 - I was assigned a task in a greenfields project that required me to design a small system, so I reached out to my team lead to collaborate with me.
 - My product manager and my team lead asked me to do two things as the top priority, so I got them together in a conversation so we could work it out as a team.
+- I noticed that a change I was making may affect another team, so I reached out to that team directly to prevent surprises.
 
 </details>
 

--- a/Software-Engineering/L3-Senior-Software-Engineer.md
+++ b/Software-Engineering/L3-Senior-Software-Engineer.md
@@ -21,6 +21,7 @@
 - I set up or maintained an automated integration and delivery pipeline.
 - I determined the technical direction within a brown-field project.
 - I made pragmatic decisions in order to ship a product.
+- I guided my team's choice of safety nets, making appropriate risk trade-offs to balance delivery and quality
 - People asked me for my opinion when making technical decisions because I had a proven track record of making wise choices.
 
 </details>

--- a/Software-Engineering/L4-Lead-Software-Engineer.md
+++ b/Software-Engineering/L4-Lead-Software-Engineer.md
@@ -57,7 +57,8 @@
 <summary>Examples</summary>
 
 - I identified the work involved with delivering a Pitch, broke it into tasks and managed the project to completion.
-- I provided principles to my team that allowed other engineers to navigate more decisions of their own, without relying on me as a sole decision maker
+- I provided principles to my team that allowed other engineers to navigate more decisions of their own, without relying on me as a sole decision maker.
+- I accurately documented the options considered in decision making to ensure that we did not re-tread the same ground next time.
 - I took ownership of my team's retrospective process, making sure everyone had a voice in how our team works and evolves together.
 - I performed interviews for engineering candidates, providing detailed and useful feedback 
 - I confidently pitched an idea, positively influencing and convincing people to take decisive action.

--- a/Software-Engineering/L4-Lead-Software-Engineer.md
+++ b/Software-Engineering/L4-Lead-Software-Engineer.md
@@ -64,6 +64,7 @@
 - I effectively steered technical and non-technical conversations to positive outcomes.
 - I was typically the first to take responsibility for reducing waste in our process.
 - I noticed a project was going to become blocked by another team, or take longer than expected, so I pulled together relevant stakeholders to propose an updated plan and reach a consensus.
+- I thoughtfully challenged and provided alternatives to a direction given by my manager or a Principal Software Engineer, with good results.
 
 </details>
 

--- a/Software-Engineering/L4-Lead-Software-Engineer.md
+++ b/Software-Engineering/L4-Lead-Software-Engineer.md
@@ -44,6 +44,7 @@
 ## 🧭 Culture and Leadership
 
 - I encompass all of the qualities listed in [Leadership](https://github.com/OctopusDeploy/People/blob/main/Leadership.md)
+- I avoid becoming a bottleneck, by setting up other engineers on my team for success for longer periods of time before needing to check back in
 - I make sure difficult work that needs to be done gets done, like hard debugging, incident response, and reverse-engineering tasks
 - I understand our organisation structure and how we schedule work, and help my team find their highest value contributions in this environment.
 - I am comfortable with transparently assessing risk, making recommendations, escalating appropriately, and dealing with the consequences along the way.
@@ -55,6 +56,7 @@
 <summary>Examples</summary>
 
 - I identified the work involved with delivering a Pitch, broke it into tasks and managed the project to completion.
+- I provided principles to my team that allowed other engineers to navigate more decisions of their own, without relying on me as a sole decision maker
 - I took ownership of my team's retrospective process, making sure everyone had a voice in how our team works and evolves together.
 - I performed interviews for engineering candidates, providing detailed and useful feedback 
 - I confidently pitched an idea, positively influencing and convincing people to take decisive action.

--- a/Software-Engineering/L4-Lead-Software-Engineer.md
+++ b/Software-Engineering/L4-Lead-Software-Engineer.md
@@ -38,6 +38,7 @@
 - I shared my on-the-job learning and experiences with others so they can understand and be more effective in their own roles.
 - I broke up a project in such a way that lined up appropriate challenges for each of my teammates that helped them grow.
 - I had some difficult conversations with my teammates, challenging them directly while showing them my care for them personally.
+- I adjusted my interactions to adapt to the different working styles and needs of individuals on my team.
 
 </details>
 

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -32,6 +32,7 @@
 - I am an expert mentor and teacher.
 - I am an expert at designing and reviewing software architecture and code.
 - I regularly provide training and support for new methods, tools, and patterns.
+- I broaden my own impact by empowering those around me.
 - I am curious, listen, and encourage debate.
 - I allow myself to be persuaded by great ideas.
 
@@ -41,6 +42,7 @@
 - I was consistently in demand for design and code review.
 - I was recognized by engineers in multiple teams as an expert mentor and teacher.
 - I helped a team make a course correction based on new information or ideas.
+- I provided appropriate technical freedom, and framing, that allowed the Lead Software Engineers on my teams to thrive independently.
 
 </details>
 

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -33,6 +33,7 @@
 - I am an expert at designing and reviewing software architecture and code.
 - I regularly provide training and support for new methods, tools, and patterns.
 - I broaden my own impact by empowering those around me.
+- I collaborate with managers to identify and find ways to fill any gaps in technical skills required in my teams.
 - I am curious, listen, and encourage debate.
 - I allow myself to be persuaded by great ideas.
 


### PR DESCRIPTION
This PR proposes refinements to the Software Engineering ladder, based on suggestions from Engineering Managers following the most recent performance review cycle.

These refinements should not affect the way that anyone is evaluated in their next performance review; they should only result in _existing expectations_ being written down and understood more clearly and consistently across all of Engineering.

We plan to follow a similar process after each performance cycle going forward. To understand more about the principles and process behind  these refinements, reach out to your manager, or see:
- [How we use calibration to refine our role ladders](https://octopushq.atlassian.net/wiki/spaces/RND/pages/2236940315/Engineering+calibration+process#How-we-use-calibration-to-refine-our-role-ladders) (internal wiki link)

If you are on this ladder and have any concerns or feedback about the proposed refinements, please reach out to your manager.

- [x] 2022-07-20 Propose post-calibration role ladder refinement process ([internal link](https://octopushq.atlassian.net/wiki/spaces/RND/pages/2236940315/Engineering+calibration+process#How-we-use-calibration-to-refine-our-role-ladders))
- [x] 2022-07-27 Hold post-calibration role ladder refinement workshop (collate suggestions and voting from Engineering Managers)
- [x] 2022-08-04 Incorporate highest-voted suggestions in this PR
- [x] 2022-08-18 Collate any further feedback via EMs, then merge PR