### PR TITLE
Iterates on the PSE role definition

### DIFF
--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -80,7 +80,7 @@
 - I identified a problem that was timely, important, and impactful, and worked closely with product, engineering, and executive stakeholders to articulate and refine a solution and delivery plan.
 - I identified a significant problem that was increasing cognitive load for engineers resulting in multiple defects, then created a lasting best-fit solution that aligned with our strategy and solved the problem.
 - I identified a pattern of organisational dysfunction that was causing poor outcomes, shared my observations with my leadership team, and escalated the signal effectively, resulting in the dysfunction being corrected and collectively getting better outcomes.
-- I regularly shared timely information in the right forums, like Slack and R&D Weekly, to amplify the work being done by my team(s), detect misalignment or surprises, and build confidence in our collective delivery plans.
+- I regularly shared timely information in the right forums, like Slack and R&D Weekly, to amplify the work being done by my team(s), to detect misalignment or surprises, and to build confidence in our collective delivery plans.
 - Instead of simply patching or extending an existing solution that was not fit for purpose anymore, my contribution opened up a whole new area of strategic possibility.
 - I regularly participated in our code review and interview processes and provided feedback on how they could be improved.
 

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -6,7 +6,7 @@
 - **Impact radius**: Group
 - **Evaluation**: Director
 - **Responsibility and direction needed**: I drive technical strategy in alignment with product strategy for my group. I develop that technical strategy and deliver good outcomes through it, with minimal oversight.
-- **Links**: [2023/24 Octopus Technical Strategy](https://docs.google.com/document/d/1onaZ7qRWc7BSLWyGw8duIIlOCd2k812zMIXXtlBfXL8/edit#heading=h.a65d8nqv4wgr) | [Target Architecture](https://github.com/OctopusDeploy/OctopusDeploy/tree/main/docs/target-architecture)
+- **Glossary (examples from 2023/24)**: ["Octopus Technical Strategy"](https://docs.google.com/document/d/1onaZ7qRWc7BSLWyGw8duIIlOCd2k812zMIXXtlBfXL8/edit#heading=h.a65d8nqv4wgr) | ["Target Architecture"](https://github.com/OctopusDeploy/OctopusDeploy/tree/main/docs/target-architecture)
 
 ## 🦉 Domain expertise
 

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -118,7 +118,7 @@
 - I regularly tried the software delivered by my teams (I "tasted the food") and provided feedback where the reliability, usability, or functionality didn't meet our standard.
 - I identified a risk in our product strategy or delivery that required a difficult tradeoff and influenced a change to mitigate that risk.
 - I built an influential case to change direction/priority with a focus on promoting customer success.
-- I helped transform a customer at risk of churn into a case study. I did this by joining several calls with the customer, understanding the big picture, diagnosing the critical problems, making the customer feel heard, and ultimately delivering on our commitments.
-- I helped close-win a complex deal where my contributions provided the buyer with confidence in the functionality and quality of the services we offer today, and/or confidence in the product direction aligned to my group/teams. I also identified some areas we can improve in our current service offerings that will simplify similar deals in the future.
+- I joined several calls with a customer who was at risk of churn. I used my listening skills and my insight into the technical capabilities of our product to add clarity to the discussion. This enabled us to transform this customer into a case study.
+- I was pulled into a complex deal negotiation. I used my insight into the functionality and quality of the services we offer today, and my group's product direction, to provide the buyer with confidence. This enabled the deal to get to Closed-Won.
 
 </details>

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -66,7 +66,6 @@
 ## 🧭 Culture and Leadership
 
 - I am a proponent of [operational excellence](https://en.wikipedia.org/wiki/Operational_excellence) and [learning from incidents](https://www.learningfromincidents.io/about).
-- I get things right a lot of the time.
 - I create an environment where others feel safe to take risks and make mistakes, by modeling vulnerability, thinking in the open, being wrong sometimes, and accepting corrections.
 - I generate energy in the teams I work with, motivating them to achieve great outcomes.
 - I facilitate effective and timely decision making, especially when the decision affects multiple teams.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -39,14 +39,15 @@
 ## 🌱 Teaching and Mentoring
 
 - I am an expert mentor and teacher.
+- I am curious, listen, and encourage healthy debate.
+- I allow myself to be persuaded by great ideas.
 - I create clarity by communicating complex things in simple and accessible ways.
 - I understand my broadest impact comes from empowering those around me.
 - I am an expert at designing and reviewing software architecture and code.
 - I help teams and individuals understand our technical strategy, how it connects to our product strategy, and the things we are doing to progress it.
 - I regularly provide training and support for new methods, tools, and patterns.
+- I actively share knowledge relevant to multiple teams.
 - I collaborate with managers and lead software engineers to identify and find ways to fill any gaps in technical skills required in my teams.
-- I am curious, listen, and encourage healthy debate.
-- I allow myself to be persuaded by great ideas.
 
 <details>
 <summary>Examples</summary>
@@ -64,6 +65,7 @@
 
 ## 🧭 Culture and Leadership
 
+- I am a proponent of [operational excellence](https://en.wikipedia.org/wiki/Operational_excellence) and [learning from incidents](https://www.learningfromincidents.io/about).
 - I get things right a lot of the time.
 - I create an environment where others feel safe to take risks and make mistakes, by modeling vulnerability, thinking in the open, being wrong sometimes, and accepting corrections.
 - I generate energy in the teams I work with, motivating them to achieve great outcomes.
@@ -72,12 +74,12 @@
 - I recognise patterns of organisational dysfunction, by observing data points, amplifying these signals, and advocating effectively for improvement.
 - I am an advisor or contributor to the leadership teams in my group.
 - I set a positive example throughout the company for quality, accountability, and responsibility.
-- I actively share knowledge relevant to product delivery teams.
 - I help define hiring standards and practices.
 
 <details>
 <summary>Examples</summary>
 
+- During a post-incident review, I recognised a valuable lesson and found a way to disseminate the lesson throughout R&D.
 - I drove an entire multiteam program from inception through to shipping code, without regular oversight.
 - I collaborated with other senior leaders to ensure I was aware of all major initiatives at Octopus and could account for them in my own initiatives.
 - The teams I work with are consistently winning. They chose ambitious targets, managed scope and expectations effectively, and delivered customer value frequently with customer adoption trends going in the right direction.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -112,7 +112,7 @@
 - I helped a team pivot effectively in response to a direction change.
 - I helped a team find a faster path to market/customer value/adoption, helping them make acceptable tradeoffs in scope, time, and quality.
 - I identified a risk where multiple teams would make life harder for each other, got them aligned, and accelerated their deliveries.
-- I contributed to the Octopus blog, a webinar, or a conference, explaining a lesson we learned as a way to reinforce the learning and to attract customers and potential future employees.
+- I contributed publicly to the Octopus blog, a webinar, or a conference, explaining a lesson we learned as a way to reinforce the learning and to attract customers and potential future employees.
 - I participated actively and willingly in discovery activities, like customer research calls, and generated insights that improved overall customer outcomes.
 - I noticed one of my teams getting bogged down in delivery. I helped them tease apart their scope and sequence their work to get themselves unblocked and get back to delivering value more quickly.
 - I regularly tried the software delivered by my teams (I "tasted the food") and provided feedback where the reliability, usability, or functionality didn't meet our standard.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -104,7 +104,7 @@
 - I hold myself and my teams to a high standard of quality, thinking holistically about reliability, usability, and functionality.
 - I am responsive to changes in product priorities, keeping multiple teams focused on important, high-value efforts.
 - I inform product strategy by helping senior leadership understand the organisation's engineering capabilities and technical strategy.
-- I help people from other departments, primarily support, customer success, revenue, and marketing, when my expertise will deliver better outcomes for our customers.
+- I collaborate with people from other departments, primarily support, customer success, revenue, and marketing, when my expertise will help us deliver better outcomes for our customers.
 
 <details>
 <summary>Examples</summary>

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -66,7 +66,7 @@
 - I facilitate effective and timely decision making, especially when the decision affects multiple teams.
 - I build solutions that improve the productivity and/or quality of work of many people/teams.
 - I recognise patterns of organisational dysfunction, by observing data points, amplifying these signals, and advocating effectively for improvement.
-- I am a net-positive advisor or contributor to the leadership teams in my group.
+- I am an advisor or contributor to the leadership teams in my group.
 - I set a positive example throughout the company for quality, accountability, and responsibility.
 - I actively share knowledge relevant to product delivery teams.
 - I help define hiring standards and practices.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -101,7 +101,7 @@
 - I work with my teams (including product managers and designers) to ensure the best outcomes for our customers and continued product/market fit.
 - I find the balance between doing it right and getting it done.
 - I am an expert at managing scope, finding ways to help my teams consistently deliver the high value to customers at speed.
-- I hold myself and my teams to a high standard of quality, with a specific focus on reliability, usability, and functionality.
+- I hold myself and my teams to a high standard of quality, thinking holistically about reliability, usability, and functionality.
 - I am responsive to changes in product priorities, keeping multiple teams focused on important, high-value efforts.
 - I inform product strategy by helping senior leadership understand the organisation's engineering capabilities and technical strategy.
 - I help people from other departments, primarily support, customer success, revenue, and marketing, when my expertise will deliver better outcomes for our customers.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -39,7 +39,7 @@
 ## 🌱 Teaching and Mentoring
 
 - I am an expert mentor and teacher.
-- I am curious, listen, and encourage healthy debate.
+- I am curious, listen, and encourage healthy conflict.
 - I allow myself to be persuaded by great ideas.
 - I create clarity by communicating complex things in simple and accessible ways.
 - I understand my broadest impact comes from empowering those around me.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -72,7 +72,7 @@
 - I facilitate effective and timely decision making, especially when the decision affects multiple teams.
 - I build solutions that improve the productivity and/or quality of work of many people/teams.
 - I recognise patterns of organisational dysfunction, by observing data points, amplifying these signals, and advocating effectively for improvement.
-- I am an advisor or contributor to the leadership teams in my group.
+- I am a contributor to or member of the leadership teams in my group.
 - I set a positive example throughout the company for quality, accountability, and responsibility.
 - I help define hiring standards and practices.
 

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -6,29 +6,33 @@
 - **Impact radius**: Group
 - **Evaluation**: Director
 - **Responsibility and direction needed**: I drive technical strategy in alignment with product strategy for my group. Point me in the right direction with helpful constraints and good outcomes happen with minimal oversight.
+- **Links**: [2023/24 Octopus Technical Strategy](https://docs.google.com/document/d/1onaZ7qRWc7BSLWyGw8duIIlOCd2k812zMIXXtlBfXL8/edit#heading=h.a65d8nqv4wgr) | [Target Architecture](https://github.com/OctopusDeploy/OctopusDeploy/tree/main/docs/target-architecture)
 
 ## 🦉 Domain expertise
 
-- I maintain a clear and understandable vision for the technical direction for teams within my group.
-- I have a deep understanding of the technical strategy and target architecture aligned with my group.
-- I help teams in my group make critical product architecture and implementation decisions that result in better outcomes.
-- I have a broad understanding of the Octopus technical strategy and target architecture.
-- I assist in maintaining the Octopus technical strategy by contributing helpful ideas and peer review.
-- I am an effective custodian for part of the Octopus target architecture.
-- I contribute to the engineering standards and principles used across Octopus.
-- I manage technical risks effectively, and architect to reduce technical risk.
-- I collaborate with other Principal Software Engineers to ensure we are making cohesive and complimentary decisions that align with the Octopus technical strategy.
+- Within my group:
+    - I maintain a clear and understandable technical direction for teams within my group to help them achieve their missions with high-quality at speed.
+    - I have a deep understanding of the technical direction for all teams within my group so I can detect and correct issues early.
+    - I help teams in my group make critical product architecture and implementation decisions that result in better outcomes.
+    - I manage technical risks effectively, and architect to reduce technical risk.
+- Across Octopus:
+    - I have a broad understanding of the Octopus technical strategy and target architecture.
+    - I am an effective custodian for part of the Octopus target architecture.
+    - I assist in maintaining the Octopus technical strategy by contributing helpful ideas and peer review.
+    - I contribute to the engineering standards and principles used across Octopus.
+    - I collaborate with other Principal Software Engineers to ensure we are making cohesive and complimentary decisions that align with the Octopus technical strategy.
 
 <details>
 <summary>Examples</summary>
 
-- I successfully completed complex tasks spanning multiple domains and teams with high impact. 
-- I contributed to building blocks or core technologies used by a variety of teams.
+- I successfully completed complex tasks spanning multiple domains and teams with high impact.
+- I explored ahead of my team(s) and helped build a technical direction to achieve their mission. I did some exploration solo and some exploration with the team. We experimented with different approaches. We discovered risks and accelerators. We updated the plan when we uncovered new risks/accelerators.
 - I helped a team reduce complexity and risk through sound architectural thinking resulting in better outcomes.
 - I developed a plan to evolve the architecture of a particularly difficult/risky/ambigious part of the core components of Octopus iterating in the open with other people using techniques like RFCs and presentations/breakouts at R&D Weekly and RADAR sessions.
 - I worked with teams to manage multiple conflicting priorities, navigated difficult tradeoffs, and helped sequence work resulting in the best collective outcome.
 - I collaborated with another principal engineer to ensure that a feature I was helping a team with would support a feature I knew another team was planning.
 - I developed a section of the Octopus target architecture, which required a thorough understanding of the problem space, proposing potential solutions, and offering a strong and informed opinion on the best solution.
+- I contributed to building blocks or core technologies used by a variety of teams.
 
 </details>
 

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -61,7 +61,7 @@
 ## 🧭 Culture and Leadership
 
 - I get things right a lot of the time.
-- I create an environment where others feel safe to take risks and make mistakes, by modeling vulnerability, thinking in the open, okay with being wrong sometimes, and accepting corrections.
+- I create an environment where others feel safe to take risks and make mistakes, by modeling vulnerability, thinking in the open, being wrong sometimes, and accepting corrections.
 - I generate energy in the teams I work with, motivating them to achieve great outcomes.
 - I facilitate effective and timely decision making, especially when the decision affects multiple teams.
 - I build solutions that improve the productivity and/or quality of work of many people/teams.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -98,7 +98,7 @@
 - I have a deep understanding of my group's product offerings and product strategy.
 - I understand what technical challenges are most impacting our customers at present, and how my own plans and the Octopus technical strategy seek to solve them.
 - I am able to anticipate and adapt systems and practices to changes in load, usage, and customer requirements.
-- I work closely with my product managers and designers to ensure the best outcomes for our customers and continued product/market fit.
+- I work with my teams (including product managers and designers) to ensure the best outcomes for our customers and continued product/market fit.
 - I find the balance between doing it right and getting it done.
 - I am an expert at managing scope, finding ways to help my teams consistently deliver the high value to customers at speed.
 - I hold myself and my teams to a high standard of quality, with a specific focus on reliability, usability, and functionality.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -94,7 +94,7 @@
 
 ## 🏆 Customer Success
 
-- I have a broad understanding of our product offerings and product strategy.
+- I have a broad understanding of Octopus product offerings and product strategy.
 - I have a deep understanding my group's product offerings and product strategy.
 - I understand what technical challenges are most impacting our customers at present, and how my own plans and the Octopus technical strategy seek to solve them.
 - I am able to anticipate and adapt systems and practices to changes in load, usage, and customer requirements.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -79,7 +79,7 @@
 <details>
 <summary>Examples</summary>
 
-- During a post-incident review, I recognised a valuable lesson and found a way to disseminate the lesson throughout R&D.
+- During an incident postmortem, I recognised a valuable lesson and found a way to disseminate the lesson throughout R&D.
 - I drove an entire multiteam program from inception through to shipping code, without regular oversight.
 - I collaborated with other senior leaders to ensure I was aware of all major initiatives at Octopus and could account for them in my own initiatives.
 - The teams I work with are consistently winning. They chose ambitious targets, managed scope and expectations effectively, and delivered customer value frequently with customer adoption trends going in the right direction.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -95,7 +95,7 @@
 ## 🏆 Customer Success
 
 - I have a broad understanding of Octopus product offerings and product strategy.
-- I have a deep understanding my group's product offerings and product strategy.
+- I have a deep understanding of my group's product offerings and product strategy.
 - I understand what technical challenges are most impacting our customers at present, and how my own plans and the Octopus technical strategy seek to solve them.
 - I am able to anticipate and adapt systems and practices to changes in load, usage, and customer requirements.
 - I work closely with my product managers and designers to ensure the best outcomes for our customers and continued product/market fit.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -11,8 +11,9 @@
 ## 🦉 Domain expertise
 
 - Within my group:
-    - I maintain a clear and understandable technical direction for teams within my group to help them achieve their missions with high-quality at speed.
-    - I have a deep understanding of the technical direction for all teams within my group so I can detect and correct issues early.
+    - I maintain a clear and understandable technical direction for my teams within my group to help them achieve their missions with high-quality at speed.
+    - I have a deep understanding of the technical direction of my teams within my group so I can detect and correct issues early.
+    - I understand the general technical direction of other teams at Octopus so I can detect and correct issues early.
     - I help teams in my group make critical product architecture and implementation decisions that result in better outcomes.
     - I manage technical risks effectively, and architect to reduce technical risk.
 - Across Octopus:

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -5,7 +5,7 @@
 - **Thinking horizon**: 1 year
 - **Impact radius**: Group
 - **Evaluation**: Director
-- **Responsibility and direction needed**: I drive technical strategy in alignment with product strategy for my group. Point me in the right direction with helpful constraints and good outcomes happen with minimal oversight.
+- **Responsibility and direction needed**: I drive technical strategy in alignment with product strategy for my group. I develop that technical strategy and deliver good outcomes through it, with minimal oversight.
 - **Links**: [2023/24 Octopus Technical Strategy](https://docs.google.com/document/d/1onaZ7qRWc7BSLWyGw8duIIlOCd2k812zMIXXtlBfXL8/edit#heading=h.a65d8nqv4wgr) | [Target Architecture](https://github.com/OctopusDeploy/OctopusDeploy/tree/main/docs/target-architecture)
 
 ## 🦉 Domain expertise

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -1,31 +1,34 @@
 # L5: Principal Software Engineer
 
-> _I am an influential Engineering leader who identifies problems and opportunities relevant to Octopus' strategy, builds consensus to invest in solutions, and guides Engineering to deliver significant lasting change across Octopus._
+> _I am an influential Engineering leader who identifies problems and opportunities relevant to Octopus product and technical strategies, builds consensus to invest in solutions, and guides Engineering to deliver significant lasting change across Octopus._
 
-- **Planning horizon**: 1+ year
-- **Impact radius**: Group+ (15-50). Note: This role is evolving as the company grows. PSE is right at the top of our IC track. For example, the impact radius expectations of an L5 will likely grow as Octopus grows larger over the next couple years, from 2-4 teams in 2021. We expect the role to stabilise in 2022 once the company has grown to the point of needing an L6 IC engineering role.
-- **Evaluation**: Director or VP
-- **Responsibility and direction needed**: Drives technical strategy in alignment with product strategy and drives high-impact improvements across teams.
+- **Thinking horizon**: 1 year
+- **Impact radius**: Group
+- **Evaluation**: Director
+- **Responsibility and direction needed**: I drive technical strategy in alignment with product strategy for my group. Point me in the right direction with helpful constraints and good outcomes happen with minimal oversight.
 
 ## 🦉 Domain expertise
 
-- I contribute to core technologies used by a variety of teams.
-- I help teams make critical product architecture and implementation decisions.
-- I maintain a vision of the overall technical direction within my impact radius.
-- I contribute to the engineering standards and principles of the company.
-- I contribute to the Octopus technical strategy.
-- I manage technical risks, and architect to reduce technical risk.
+- I maintain a clear and understandable vision for the technical direction for teams within my group.
+- I have a deep understanding of the technical strategy and target architecture aligned with my group.
+- I help teams in my group make critical product architecture and implementation decisions that result in better outcomes.
+- I have a broad understanding of the Octopus technical strategy and target architecture.
+- I assist in maintaining the Octopus technical strategy by contributing helpful ideas and peer review.
+- I am an effective custodian for part of the Octopus target architecture.
+- I contribute to the engineering standards and principles used across Octopus.
+- I manage technical risks effectively, and architect to reduce technical risk.
 - I collaborate with other Principal Software Engineers to ensure we are making cohesive and complimentary decisions that align with the Octopus technical strategy.
 
 <details>
 <summary>Examples</summary>
 
 - I successfully completed complex tasks spanning multiple domains and teams with high impact. 
-- I helped a team reduce complexity and risk through sound architectural thinking.
-- I developed a plan to evolve the architecture of one of the core components of Octopus within my impact radius.
-- I identified a problem that was timely, important, and impactful, and worked closely with product, engineering, and executive stakeholders to articulate and refine a solution and delivery plan.
-- I worked with teams to manage multiple conflicting priorities and helped sequence work resulting in the best collective outcome.
+- I contributed to building blocks or core technologies used by a variety of teams.
+- I helped a team reduce complexity and risk through sound architectural thinking resulting in better outcomes.
+- I developed a plan to evolve the architecture of a particularly difficult/risky/ambigious part of the core components of Octopus iterating in the open with other people using techniques like RFCs and presentations/breakouts at R&D Weekly and RADAR sessions.
+- I worked with teams to manage multiple conflicting priorities, navigated difficult tradeoffs, and helped sequence work resulting in the best collective outcome.
 - I collaborated with another principal engineer to ensure that a feature I was helping a team with would support a feature I knew another team was planning.
+- I developed a section of the Octopus target architecture, which required a thorough understanding of the problem space, proposing potential solutions, and offering a strong and informed opinion on the best solution.
 
 </details>
 
@@ -35,30 +38,35 @@
 - I create clarity by communicating complex things in simple and accessible ways.
 - I understand my broadest impact comes from empowering those around me.
 - I am an expert at designing and reviewing software architecture and code.
-- I help teams and individuals understand our technical strategy, and the things we are doing to progress it.
+- I help teams and individuals understand our technical strategy, how it connects to our product strategy, and the things we are doing to progress it.
 - I regularly provide training and support for new methods, tools, and patterns.
-- I collaborate with managers to identify and find ways to fill any gaps in technical skills required in my teams.
-- I am curious, listen, and encourage debate.
+- I collaborate with managers and lead software engineers to identify and find ways to fill any gaps in technical skills required in my teams.
+- I am curious, listen, and encourage healthy debate.
 - I allow myself to be persuaded by great ideas.
 
 <details>
 <summary>Examples</summary>
 
 - I was consistently in demand for design and code review.
-- I am actively mentoring multiple Octopus engineers.
+- I became aware that I was a bottleneck and worked proactively with managers to uplift and empower other people to make the team more effective.
+- I am actively mentoring multiple Octopus engineers, including a Lead Software Engineer aspiring to become a Principal Software Engineer.
 - Engineers at Octopus seek out to work on my teams to learn from me.
 - After reviewing a code contribution from an engineer I saw could be improved, I worked directly with that engineer and their manager or team leader to uplift their skills in the identified growth area.
 - I helped a team make a course correction based on new information or ideas.
 - I provided appropriate technical freedom, and framing, that allowed the Lead Software Engineers on my teams to thrive independently.
+- I have elevated/shifted my focus significantly because the team(s) I support have been uplifted and empowered to the point they can deliver their mission with me as a sounding board.
 
 </details>
 
 ## 🧭 Culture and Leadership
 
-- I create an environment where others feel safe, by modeling vulnerability, thinking in the open, being wrong, and accepting corrections.
-- I generate energy within the teams I work with, motivating them to achieve great outcomes.
+- I get things right a lot of the time.
+- I create an environment where others feel safe to take risks and make mistakes, by modeling vulnerability, thinking in the open, okay with being wrong sometimes, and accepting corrections.
+- I generate energy in the teams I work with, motivating them to achieve great outcomes.
 - I facilitate effective and timely decision making, especially when the decision affects multiple teams.
 - I build solutions that improve the productivity and/or quality of work of many people/teams.
+- I recognise patterns of organisational dysfunction, by observing data points, amplifying these signals, and advocating effectively for improvement.
+- I am a net-positive advisor or contributor to the leadership teams in my group.
 - I set a positive example throughout the company for quality, accountability, and responsibility.
 - I actively share knowledge relevant to product delivery teams.
 - I help define hiring standards and practices.
@@ -66,9 +74,13 @@
 <details>
 <summary>Examples</summary>
 
-- I drove an entire multiteam program from inception through to shipping code, without regular technical oversight.
+- I drove an entire multiteam program from inception through to shipping code, without regular oversight.
 - I collaborated with other senior leaders to ensure I was aware of all major initiatives at Octopus and could account for them in my own initiatives.
-- I identified a significant problem/opportunity and created a lasting best-fit solution that aligned with our strategy.
+- The teams I work with are consistently winning. They chose ambitious targets, managed scope and expectations effectively, and delivered customer value frequently with customer adoption trends going in the right direction.
+- I identified a problem that was timely, important, and impactful, and worked closely with product, engineering, and executive stakeholders to articulate and refine a solution and delivery plan.
+- I identified a significant problem that was increasing cognitive load for engineers resulting in multiple defects, then created a lasting best-fit solution that aligned with our strategy and solved the problem.
+- I identified a pattern of organisational dysfunction that was causing poor outcomes, shared my observations with my leadership team, and escalated the signal effectively, resulting in the dysfunction being corrected and collectively getting better outcomes.
+- I regularly shared timely information in the right forums, like Slack and R&D Weekly, to amplify the work being done by my team(s), detect misalignment or surprises, and build confidence in our collective delivery plans.
 - Instead of simply patching or extending an existing solution that was not fit for purpose anymore, my contribution opened up a whole new area of strategic possibility.
 - I regularly participated in our code review and interview processes and provided feedback on how they could be improved.
 
@@ -76,22 +88,31 @@
 
 ## 🏆 Customer Success
 
-- I have a deep understanding of our products and product strategy.
+- I have a broad understanding of our product offerings and product strategy.
+- I have a deep understanding my group's product offerings and product strategy.
 - I understand what technical challenges are most impacting our customers at present, and how my own plans and the Octopus technical strategy seek to solve them.
 - I am able to anticipate and adapt systems and practices to changes in load, usage, and customer requirements.
-- I work closely with our product team to ensure continued product/market fit.
+- I work closely with my product managers and designers to ensure the best outcomes for our customers and continued product/market fit.
 - I find the balance between doing it right and getting it done.
+- I am an expert at managing scope, finding ways to help my teams consistently deliver the high value to customers at speed.
+- I hold myself and my teams to a high standard of quality, with a specific focus on reliability, usability, and functionality.
 - I am responsive to changes in product priorities, keeping multiple teams focused on important, high-value efforts.
 - I inform product strategy by helping senior leadership understand the organisation's engineering capabilities and technical strategy.
+- I help people from other departments, primarily support, customer success, revenue, and marketing, when my expertise will deliver better outcomes for our customers.
 
 <details>
 <summary>Examples</summary>
 
 - I helped a team pivot effectively in response to a direction change.
-- I helped a team find a faster path to market.
+- I helped a team find a faster path to market/customer value/adoption, helping them make acceptable tradeoffs in scope, time, and quality.
 - I identified a risk where multiple teams would make life harder for each other, got them aligned, and accelerated their deliveries.
-- I contributed to the Octopus blog, explaining a lesson we learned as a way to reinforce the learning and to attract customers and potential future employees.
-- I identified a risk to our product strategy and influenced a change to mitigate that risk.
+- I contributed to the Octopus blog, a webinar, or a conference, explaining a lesson we learned as a way to reinforce the learning and to attract customers and potential future employees.
+- I participated actively and willingly in discovery activities, like customer research calls, and generated insights that improved overall customer outcomes.
+- I noticed one of my teams getting bogged down in delivery. I helped them tease apart their scope and sequence their work to get themselves unblocked and get back to delivering value more quickly.
+- I regularly tried the software delivered by my teams (I "tasted the food") and provided feedback where the reliability, usability, or functionality didn't meet our standard.
+- I identified a risk in our product strategy or delivery that required a difficult tradeoff and influenced a change to mitigate that risk.
 - I built an influential case to change direction/priority with a focus on promoting customer success.
+- I helped transform a customer at risk of churn into a case study. I did this by joining several calls with the customer, understanding the big picture, diagnosing the critical problems, making the customer feel heard, and ultimately delivering on our commitments.
+- I helped close-win a complex deal where my contributions provided the buyer with confidence in the functionality and quality of the services we offer today, and/or confidence in the product direction aligned to my group/teams. I also identified some areas we can improve in our current service offerings that will simplify similar deals in the future.
 
 </details>

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -59,7 +59,7 @@
 - After reviewing a code contribution from an engineer I saw could be improved, I worked directly with that engineer and their manager or team leader to uplift their skills in the identified growth area.
 - I helped a team make a course correction based on new information or ideas.
 - I provided appropriate technical freedom, and framing, that allowed the Lead Software Engineers on my teams to thrive independently.
-- I have elevated/shifted my focus significantly because the team(s) I support have been uplifted and empowered to the point they can deliver their mission with me as a sounding board.
+- I have elevated my focus significantly because the teams I support have been uplifted and empowered to the point they can deliver their mission with me as a sounding board.
 
 </details>
 

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -83,7 +83,6 @@
 - I drove an entire multiteam program from inception through to shipping code, without regular oversight.
 - I collaborated with other senior leaders to ensure I was aware of all major initiatives at Octopus and could account for them in my own initiatives.
 - The teams I work with are consistently winning. They chose ambitious targets, managed scope and expectations effectively, and delivered customer value frequently with customer adoption trends going in the right direction.
-- I identified a problem that was timely, important, and impactful, and worked closely with product, engineering, and executive stakeholders to articulate and refine a solution and delivery plan.
 - I identified a significant problem that was increasing cognitive load for engineers resulting in multiple defects, then created a lasting best-fit solution that aligned with our strategy and solved the problem.
 - I identified a pattern of organisational dysfunction that was causing poor outcomes, shared my observations with my leadership team, and escalated the signal effectively, resulting in the dysfunction being corrected and collectively getting better outcomes.
 - I regularly shared timely information in the right forums, like Slack and R&D Weekly, to amplify the work being done by my team(s), to detect misalignment or surprises, and to build confidence in our collective delivery plans.

--- a/Software-Engineering/L5-Principal-Software-Engineer.md
+++ b/Software-Engineering/L5-Principal-Software-Engineer.md
@@ -110,7 +110,7 @@
 <summary>Examples</summary>
 
 - I helped a team pivot effectively in response to a direction change.
-- I helped a team find a faster path to market/customer value/adoption, helping them make acceptable tradeoffs in scope, time, and quality.
+- I helped a team find a faster path to customer impact, through making acceptable tradeoffs in scope, time, and quality.
 - I identified a risk where multiple teams would make life harder for each other, got them aligned, and accelerated their deliveries.
 - I contributed publicly to the Octopus blog, a webinar, or a conference, explaining a lesson we learned as a way to reinforce the learning and to attract customers and potential future employees.
 - I participated actively and willingly in discovery activities, like customer research calls, and generated insights that improved overall customer outcomes.


### PR DESCRIPTION
The goal of this change is to improve the clarity of the description so that:

- It's easier for L5's and their managers to share understanding of the expectations of the role
- It's easier for L4's (potential L5's) to have a clearer understanding of what's required to progress to L5 (if they have the appetite)

# Key changes

- Clarify the focus of a PSE is their group, then the rest of Octopus
- Clarify where we expect PSEs to be "t-shaped" (broad understanding versus deep understanding)
- Introduces some traits I've observed of the best PSEs
  - Identifying patterns of organisational dysfunction and advocating effectively for improvement
  - Championing operational excellence and learning from incidents
  - Working with peers in other departments, like support/sales/marketing, to help a frustrated customer or improve overall customer outcomes

# Process

- [x] I took inspiration from the workshop we ran with Principal Engineers and Engineering Directors at the Principal Enginering onsite in April 2024: https://docs.google.com/document/d/1IU26CW0wuftc9gFaJbkTHVpTjxkslE4APO374XWaRHg/edit
- [x] I spent an afternoon reading and reflecting on the examples I've observed over the last 12 months at Octopus and added a first draft of those ideas. These mainly aligned with the Customer Success traits.
- [x] Feedback from @andrewabest 
- [x] Feedback from Engineering Directors (@hogfish @Waldo000000 @cstrzadala Ziv Levi)
- [ ] Feedback from Principal Software Engineers
- [ ] Feedback from @colinbowern 