### PR TITLE
Create L6: Senior Principal Software Engineer role

### DIFF
--- a/Software-Engineering/L6-Senior-Principal-Software-Engineer.md
+++ b/Software-Engineering/L6-Senior-Principal-Software-Engineer.md
@@ -1,0 +1,91 @@
+# L6: Senior Principal Software Engineer
+
+> _Building on the Principal Software Engineer role, I understand what matters to our business and then instigate and drive technical strategy and engineering excellence across all R&D._
+>
+> _Note: This role is right at the top of our IC track and will evolve as the company grows and its needs change._
+
+- **Planning horizon**: 3+ years
+- **Impact radius**: Impact radius: R&D + Company (~100 people).
+- **Evaluation**: VP of Engineering
+- **Responsibility and direction needed**: No direction is required. Expected to understand business priorities and develop technical strategy that supports those priorities. Drives the product-level technical strategy with company-wide impact and ~3-year impact horizon. High autonomy and accountability are expected.
+
+## 🦉 Domain expertise
+
+> _I am familiar with the entire technical landscape at Octopus with proven depth and experience in several areas of technical and domain expertise._
+- I can contribute meaningfully to a conversation about any area in Octopus both inside and outside R&D.
+- I participate heavily in early-stage decision making activities with other principal engineers and teams. The business context and technical knowledge I bring to these conversations leads to higher quality decisions being made.
+- I own the definition of our product’s target architecture, using a holistic view of our engineering organisation, product, customer insights, and business goals to articulate and prioritise the architectural shifts necessary to achieve those goals within a written target architecture.
+- I ensure product architecture and implementation decisions being made by teams are aligned with our target architecture.
+
+<details>
+<summary>Examples</summary>
+
+- I provided ongoing guidance to a principal and lead engineer as they developed our new execution pipeline, using my expertise of the existing execution pipeline and target architecture to provide critical, timely feedback.
+- I championed and led the definition of a target architecture for Octopus Server, knowing that doing so would unlock our ability to more effectively execute the architectural shifts required at scale by enabling engineers to reason about target architecture in their day-to-day work.
+- I helped validate plans for a new commercial stack with our VP Product, using my knowledge of Octopus Server and cloud architecture to support designs for product experience changes, and discussing buy / build tradeoffs for the major components involved.
+
+</details>
+
+## 🌱 Teaching and Mentoring
+
+> _ I collaborate effectively with engineering managers to champion a high-performance engineering culture helping them create an environment for continuous growth and development._
+
+- I have a strong positive influence over the engineering career framework, including how we interview candidate engineers and help successful candidates do the best work of their lives at Octopus.
+- I actively mentor current and aspiring principal engineers and work closely with their managers to build credible and helpful development plans.
+- I inspire senior and diverse talent to join Octopus.
+
+<details>
+<summary>Examples</summary>
+
+- I identified a gap in our hiring process that risked choosing the wrong people and helped rectify the problem.
+- I was instrumental in helping some aspiring principal engineers demonstrate their growing impact resulting in their promotion.
+- I mentor other principal engineers helping them increase their impact and engagement over time.
+- I connect with several senior and diverse technical leaders. The goal is mutually beneficial peer support, but could also result in them joining Octopus in the future.
+- I presented at some developer conferences/meetups with strong positive feedback from attendees who may join Octopus in the future.
+
+</details>
+
+## 🧭 Culture and Leadership
+
+> _I shape Octopus's culture and personify its values. When I contribute at any level, from company executives to individual teams, I create clarity, generate energy, and deliver success._
+
+- I shape Octopus's culture and personify its values.
+- I create a culture of high performance, inclusion, and psychological safety that is resilient and adaptable to organisational change.
+- I am distinguished by humility, curiosity, servant leadership, and healthy conflict.
+- I bring out the best in other leaders and teams.
+- I generate energy in teams across all R&D, motivating them to achieve great outcomes.
+- I use my knowledge of our business and product strategy to identify problems and instigate action that increases our chances of business success.
+- I have a sense of responsibility and obligation to act on opportunities and create alignment across the engineering org/company to improve outcomes for our customers.
+- I take complex, chaotic problem spaces and pass on clarity to teams and stakeholders, helping them reason about the biggest problems we are facing and deliver success when tackling them.
+
+<details>
+<summary>Examples</summary>
+
+- Kicking off a large initiative to deliver a large migration with a third of our engineering team contributing, I devised a set of tools and activities to quickly form and bond strong teams and align them with the work to be done, driving immediate momentum in those teams, and resulting in completing the work to be done within half the originally estimated budget.
+- When one of our teams shipped an RFC that triggered a strong reaction across R&D, I intervened and facilitated a workshop with that team and RFC respondents to align the parties on key principles, then helped broker consensus that would help us achieve the outcomes stated within the RFC.
+- I analysed our approach to testing Octopus Server, diagnosed the most important problem to solve, developed a strategy with coherent actions that will result in lasting impact, and secured funding to complete the work.
+
+</details>
+
+## 🏆 Customer Success
+
+> _I am responsible and accountable for our product-level technical strategy with company-wide impact and a ~3-year impact horizon._
+
+- I have a deep understanding of our company vision, company strategy, our product ecosystem, and our product strategy. I use this understanding to identify significant problems, create clarity, and instigate action that increases our chances of business success.
+- I work closely with cross-functional partners to develop and articulate a good technical strategy that aligns with and enables Octopus to achieve its business objectives.
+- I understand what technical challenges are most impacting our customers at present, and how my own plans and the technical strategy seek to solve them.
+- I inform company strategy by helping executive leadership understand the organisation's engineering capabilities and technical strategy.
+- I take full accountability for the far-reaching impacts of the difficult decisions we make due to my work on technical strategy.
+- I skillfully represent technical strategy to the entire company including the executive leadership team, tailoring my communication appropriate for the audience.
+- I have a strong positive influence on engineering excellence, operational excellence, and engineering engagement.
+- I drive technical transformation that positively impacts the effectiveness and engagement of R&D teams.
+
+<details>
+<summary>Examples</summary>
+
+- I authored and delivered the first R&D-level technical strategy that Octopus had produced, identifying a need to document the focus and goals of the Technical Leadership Group, so that the group’s proposed investments were clearly articulated, and could be understood and funded by the RLT.
+- I own our ongoing product-level technical strategy, ensuring it is refined and communicated regularly so that it continues to serve the evolving needs of our business, and teams are aligned with it.
+- When presenting the technical strategy to the executive team, I identified and addressed a knowledge gap the executive team had in how we host customers in Octopus Cloud, how it impacts what we can achieve on the platform, and how the current architecture of Octopus Server constrains it.
+- After an incident that had a strong negative impact on customers, I worked with our support team to connect with those customers and “lift the covers back” on the work we were undertaking that impacted them, looking to build good will by transparency and open communication.
+
+</details>

--- a/Software-Engineering/L6-Senior-Principal-Software-Engineer.md
+++ b/Software-Engineering/L6-Senior-Principal-Software-Engineer.md
@@ -28,7 +28,7 @@
 
 ## 🌱 Teaching and Mentoring
 
-> _ I collaborate effectively with engineering managers to champion a high-performance engineering culture helping them create an environment for continuous growth and development._
+> _I collaborate effectively with engineering managers to champion a high-performance engineering culture helping them create an environment for continuous growth and development._
 
 - I have a strong positive influence over the engineering career framework, including how we interview candidate engineers and help successful candidates do the best work of their lives at Octopus.
 - I actively mentor current and aspiring principal engineers and work closely with their managers to build credible and helpful development plans.


### PR DESCRIPTION
This PR publishes our working definition of the new L6: Senior Principal Software Engineer role into Octopus People.

It was originally developed in [this internal working document](https://docs.google.com/document/d/1b5NOefAvveld0rgXzhZpmzUVLsaHstrHcCstz-_fAhE/edit) and announced [internally via Slack](https://octopusdeploy.slack.com/archives/C025P7WQ3G9/p1702425441923559).