### PR TITLE
Engineering 2024 H2 role ladder calibration changes

### DIFF
--- a/Software-Engineering/L3-Senior-Software-Engineer.md
+++ b/Software-Engineering/L3-Senior-Software-Engineer.md
@@ -51,7 +51,7 @@
 - I manage difficult conversations and tactfully challenge others.
 - I improve the productivity and delivery of my team.
 - I help raise the bar for working at Octopus by providing regular code reviews and / or interviews for engineering candidates.
-- I facilitate healthy conflict through negotiation to arrive at positive, constructive outcomes.
+- I practice healthy conflict, using negotiation to arrive at positive, constructive outcomes.
 
 <details>
 <summary>Examples</summary>
@@ -61,7 +61,7 @@
 - I spotted a contentious issue that could have gone badly and facilitated everyone toward a decision that resolved the situation.
 - I recognised a problem early and got in to fix it even though it wasn't my fault.
 - I wrote a clear and concise proposal that persuaded the team to act on my idea.
-- I successfully facilitated a negotiation around the requirements of a project by bringing an engineering perspective, listening to understand Product's and Design's perspectives, and advocating for outcomes that bring the best value to our customers from all perspectives. 
+- I successfully engaged in a negotiation around the requirements of a project by bringing an engineering perspective, listening to understand Product's and Design's perspectives, and advocating for outcomes that bring the best value to our customers from all perspectives. 
 
 </details>
 

--- a/Software-Engineering/L3-Senior-Software-Engineer.md
+++ b/Software-Engineering/L3-Senior-Software-Engineer.md
@@ -51,6 +51,7 @@
 - I manage difficult conversations and tactfully challenge others.
 - I improve the productivity and delivery of my team.
 - I help raise the bar for working at Octopus by providing regular code reviews and / or interviews for engineering candidates.
+- I facilitate healthy conflict through negotiation to arrive at positive, constructive outcomes.
 
 <details>
 <summary>Examples</summary>
@@ -60,6 +61,7 @@
 - I spotted a contentious issue that could have gone badly and facilitated everyone toward a decision that resolved the situation.
 - I recognised a problem early and got in to fix it even though it wasn't my fault.
 - I wrote a clear and concise proposal that persuaded the team to act on my idea.
+- I successfully facilitated a negotiation around the requirements of a project by bringing an engineering perspective, listening to understand Product's and Design's perspectives, and advocating for outcomes that bring the best value to our customers from all perspectives. 
 
 </details>
 


### PR DESCRIPTION
From our calibration session, we talked about expecting senior engineers to have some communication skills, and that there's a big jump between L3 -> L4 around communication (From our [leadership](https://github.com/OctopusDeploy/People/blob/main/Leadership.md) capabilities). 

Workshop: https://whimsical.com/post-calibration-engineering-role-ladder-refinement-workshops-9xs7MapSCHDk6xwz58Veuk