### PR TITLE
Start adding a few examples to EM roles for Managing Teams 

### DIFF
--- a/Engineering-Management.md
+++ b/Engineering-Management.md
@@ -32,14 +32,17 @@ I ensure that my team has an environment where engineers can do their best work
 - I recognise dysfunction in my team and work effectively to resolve it in a timely manner.
 - I listen to different perspectives and I remove biases from my words and actions 
 - I create an inclusive environment for my team where it’s safe to speak up
+- I create an emotionally and psychologically safe environment for the team to allow everyone to be themselves at work and to express their ideas and opinions without negative consequences. 
 - I create a sense of connection for individuals in my team by ensuring everyone has repeated, frequent and predictable access to their colleagues and mentors
 
 <details>
 <summary>Examples</summary>
 
-- I helped my team feel connected by giving them clear expectations from me so that they didn't have to guess as what I expect from them. 
-- I created a space with my team members where they can talk with me about problems they're facing without me taking any actions, allowing them a safe space to express what's on their mind without concern of it becoming a larger issue. 
-- I invited and gave permission to everyone on my team to give me feedback at any point 
+- I ensured that a junior developer on our team had access to a mentor, myself as their manager, and their colleagues on a scheduled, frequent cadence to allow them to feel consistently connected with the team.  
+- I helped a team member feel more certain about their role by outlining my clear expectations of them in their role in a 1:1 situation. 
+- I created a space with my team members where they can talk with me about problems they're facing without me having to taking any actions, allowing them a safe space to express what's on their mind without concern of it becoming a larger issue. 
+- I gave permission to a team member to give me feedback, allowing myself to be vulnerable and open the door to feedback to allow me to improve or change my ways. 
+- I acknowledged that there is a power dynamic between myself and a junior engineer, but was able to listen to that team member and use my position to advocate for their needs. 
 
 </details>
 

--- a/Engineering-Management.md
+++ b/Engineering-Management.md
@@ -33,6 +33,15 @@ I ensure that my team has an environment where engineers can do their best work
 - I listen to different perspectives and I remove biases from my words and actions 
 - I create an inclusive environment for my team where it’s safe to speak up
 
+<details>
+<summary>Examples</summary>
+
+- I helped my team feel connected by giving them clear expectations from me so that they didn't have to guess as what I expect from them. 
+- I created a space with my team members where they can talk with me about problems they're facing without me taking any actions, allowing them a safe space to express what's on their mind without concern of it becoming a larger issue. 
+- I invited and gave permission to everyone on my team to give me feedback at any point 
+
+</details>
+
 ## L5 Senior Engineering Manager
 
 > I am an experienced Engineering Manager that leads one or more teams of engineers to deliver direct business impact. My manager can "set and forget" when it comes to my team, knowing that I can solve most problems independently using a robust managerial toolbox, and will keep them in the loop.


### PR DESCRIPTION
I'd like to start adding some examples of the EM role to help new EMs, weather they're new to Octopus, or new to EM from the IC track at Octopus. As we keep expanding, adding more and more examples will become valuable for helping these new EMs onboard into being an EM the Octopus way.  

Earlier in the year a few of us attended a workshop around supporting early career women in male-dominated fields and wrote up some of my learnings here: https://octopusdeploy.slack.com/archives/C01HEHFJKUK/p1713925356117769?thread_ts=1713913920.840279&cid=C01HEHFJKUK

We've added a point around connectedness here from that workshop: https://github.com/OctopusDeploy/People/pull/83 now I'm expanding on some examples to help support other pillars of our team around connectedness, belonging and certainty. 

These are just a few example for all the capabilities of an EM, but I'd like to keep our scope smaller for this first pass, and continue to add more examples for other capabilities over time rather do an all-in add examples for everything in one go. 

I'm looking for all feedback around the new capability and examples :) 